### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,10 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="qiu.niorgai">
 
-    <application android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
->
+    <application>
 
     </application>
 


### PR DESCRIPTION
Fix app name. Remove the library's <application> atrr, because library's setting will apply for app module,  and then if the app have not set app name or the setting is same but Multilingual strings.xml are imperfect, the app will show a error name or other side effect